### PR TITLE
Add command line parameter for invoice count

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let start_date = NaiveDate::from_ymd_opt(2021, 1, 1).expect("Invalid start date");
     let end_date = NaiveDate::from_ymd_opt(2024, 6, 16).expect("Invalid end date");
 
-    for _ in 0..1000000 {
+    let args: Vec<String> = env::args().collect();
+    let num_invoices: i32 = args.get(1).expect("Please provide the number of invoices to create as a command line argument").parse().expect("The provided argument must be an integer");
+
+    for _ in 0..num_invoices {
         let invoice_date = random_date_in_range(&mut rng, start_date, end_date)
             .and_hms_opt(0, 0, 0)
             .expect("Invalid time");
@@ -77,7 +80,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     let duration = start_time.elapsed();
-    println!("Inserted 1,000,000 invoices in: {:?}", duration);
+    println!("Inserted {} invoices in: {:?}", num_invoices, duration);
 
     Ok(())
 }


### PR DESCRIPTION
Related to #1

Implements the feature to accept a command line parameter for the number of invoices to create, replacing the previously hard-coded value.

- Parses the command line argument to determine the number of invoices to create using `std::env::args`.
- Replaces the hard-coded value of `1000000` with the parsed command line argument, allowing dynamic setting of the number of invoices to generate.
- Adds error handling for cases where the command line argument is not provided or cannot be parsed to an integer, ensuring robustness.
- Updates the `println!` statement at the end of the `main` function to reflect the dynamic number of invoices inserted based on the command line argument, enhancing feedback to the user.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/burggraf/invoice_generator/issues/1?shareId=7309c2e8-2f7a-4da4-a2f5-4eb7cd6b9696).